### PR TITLE
Temporarily remove unregistered PALEOco2sys package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,11 @@ version = "0.1.0"
 
 [deps]
 PALEOboxes = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
-PALEOco2sys = "3bc61bc2-d22e-4ed6-b77d-fe89e7d9e944"
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 
 [compat]
 PALEOboxes = "0.20.4, 0.21"
-PALEOco2sys = "0.1.0"
 SIMD = "3.4"
 TestEnv = "1"
 

--- a/src/PALEOaqchem.jl
+++ b/src/PALEOaqchem.jl
@@ -34,7 +34,7 @@ StoichPars() = PB.ParametersTuple(
 )
 
 
-include("CarbChem.jl")
+# include("CarbChem.jl")
 
 include("Remin.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,6 @@ using Documenter
 
 @testset "PALEOaqchem all" begin
 
-include("runcarbchemtests.jl")
+# include("runcarbchemtests.jl")
 
 end


### PR DESCRIPTION
Removed temporarily to allow Julia package registration, while PALEOco2sys is still  in the 3 day queue to register.