### PR TITLE
Bug fixes for Fe-S system alkalinity

### DIFF
--- a/src/CarbChem.jl
+++ b/src/CarbChem.jl
@@ -43,7 +43,10 @@ Base.@kwdef mutable struct ReactionCO2SYS{P} <: PB.AbstractReaction
         # PB.ParStringVec("output_consts", String[], 
         #     description="PALEOcarbchem eqb constants etc to include as output variables"),
 
-        PB.ParStringVec("outputs", ["pCO2", "xCO2dryinp"], 
+        PB.ParStringVec("outputs", ["pCO2", "xCO2dryinp"],
+            allowed_values=["H", "OH", "TS", "HSO4", "TF", "HF", "TCi", "CO2", "HCO3", "CO3", "CAlk", "fCO2", "pCO2", "xCO2dryinp",
+                "TB", "BAlk", "TP", "H3PO4", "H2PO4", "HPO4", "PO4", "PAlk", "TSi", "SiAlk", "TH2S", "HSAlk", "TNH3", "NH3Alk",
+                "Ca", "OmegaCA", "OmegaAR"], # needs to match PALEOcarbchem.ResultNames
             description="PALEOcarbchem output concentrations etc to include as output variables"),
 
         PB.ParBool("output_pHtot", true, 

--- a/src/PALEOcarbchem/Solvers.jl
+++ b/src/PALEOcarbchem/Solvers.jl
@@ -31,15 +31,47 @@ Get human-readable description of `resultName`
 """
 function getResultDescription(resultName::AbstractString)
     ResultDescriptions = (
-        ("pCO2",        "atm",      "CO2 partial pressure"),
-        ("xCO2dryinp",  "",         "mixing ratio of CO2 in dry air at 1 atm (always > pCO2 due to H2O vapour pressure)"),
+        # water
+        ("H",           "mol kg-1", "Hydrogen ion (free) concentration"),
+        ("OH",          "mol kg-1", "Hydroxyl ion concentration"),
+        # sulphate
+        ("TS",          "mol kg-1", "Sulphate total concentration"),
+        ("HSO4",          "mol kg-1", "HSO4- concentration"),
+        # fluoride
+        ("TF",          "mol kg-1", "Fluoride total concentration"),
+        ("HF",          "mol kg-1", "Fluoride HF concentration"),
+        # carbon
+        ("TCi",         "mol kg-1", "DIC total concentration"),
         ("CO2",         "mol kg-1", "CO2 concentration"),
-        ("HCO3",        "mol kg-1", "bicarbonate ion concentration"),
-        ("CO3",         "mol kg-1", "carbonate ion concentration"),
+        ("HCO3",        "mol kg-1", "bicarbonate ion HCO3- concentration"),
+        ("CO3",         "mol kg-1", "carbonate ion CO3-- concentration"),
+        ("CAlk",        "mol kg-1", "carbon contribution to total alkalinity (HCO3 + 2*CO3)"),
+        ("fCO2",        "atm",      "CO2 fugacity"),
+        ("pCO2",        "atm",      "CO2 partial pressure (fugacity corrected)"),
+        ("xCO2dryinp",  "",         "mixing ratio of CO2 in dry air at 1 atm (always > pCO2 due to H2O vapour pressure)"),
+        # boron
+        ("TB",          "mol kg-1", "Boron total concentration"),
+        ("BAlk",        "mol kg-1", "Boron B(OH)_4^- concentration (= boron contribution to total alkalinity)"),
+        # phosphorus
+        ("TP",          "mol kg-1", "Phosphate total concentration"),
+        ("H3PO4",       "mol kg-1", "Phosphate H3PO4 concentration"),
+        ("H2PO4",       "mol kg-1", "Phosphate H2PO4- concentration"),
+        ("HPO4",        "mol kg-1", "Phosphate HPO4-- concentration"),
+        ("PO4",         "mol kg-1", "Phosphate PO4--- concentration"),
+        ("PAlk",        "mol kg-1", "Phosphate contribution to total alkalinity (-H3PO4 + HPO4 + 2*PO4)"),
+        # silica
+        ("TSi",         "mol kg-1", "Silicate total concentration"),
+        ("SiAlk",       "mol kg-1", "Silicate H3SO4- concentration (= silicate contribution to total alkalinity)"),
+        # sulphide
+        ("TH2S",        "mol kg-1", "Sulphide total concentration"),
+        ("HSAlk",       "mol kg-1", "Sulphide HS- concentration (= sulphide contribution to total alkalinity)"),
+        # ammonia
+        ("TNH3",        "mol kg-1", "Ammonia + ammonium total concentration (NH3 + NH_4^+)"),
+        ("NH3Alk",      "mol kg-1", "Ammonia NH3 concentration (= ammonia contribution to total alkalinity)"),
+        # calcium and carbonate saturation
+        ("Ca",          "mol kg-1", "Ca concentration"),
         ("OmegaCA",     "",         "calcite saturation"),
         ("OmegaAR",     "",         "aragonite saturation"),
-        ("TB",         "mol kg-1", "Boron total concentration"),
-        ("BAlk",        "mol kg-1", "Boron B(OH)_4^- concentration"),
     )
 
     for resultdesc in ResultDescriptions

--- a/src/Remin.jl
+++ b/src/Remin.jl
@@ -20,18 +20,20 @@ const default_reminOrgOxO2 = PB.RateStoich(
 const default_reminOrgOxFeIIIOx = PB.RateStoich(
     PB.VarProp("reminOrgOxFeIIIOx", "mol O2eq yr-1", "oxygen consumption (-ve) by remineralization",
         attributes=(:calc_total=>true,)),
-    ((4.0, "FeIIIOx"), (-4.0, "FeII"), (8.0, "TAlk")),
+    ((4.0, "FeIIIOx"), (-4.0, "FeII"), (-8.0, "TAlk")), # NB: stoichiometry is *-1
     sms_prefix="soluteflux_", 
     sms_suffix="",
     processname="remin",
 )
 
 "Stoichiometry and fractionation for organic matter oxidation by SO4.
- NB: normalized to O2eq"
+ NB: normalized to O2eq
+    0.5 SO4-- + H+ -> 0.5 H2S [+O2]
+ "
 const default_reminOrgOxSO4 = PB.RateStoich(
     PB.VarProp("reminOrgOxSO4", "mol O2eq yr-1", "2 * sulphate consumption (-ve) by remineralization",
         attributes=(:calc_total=>true,)),
-    ((0.5, "SO4::Isotope"), (-0.5, "H2S::Isotope"), (-1.0, "TAlk")),
+    ((0.5, "SO4::Isotope"), (-0.5, "H2S::Isotope"), (-1.0, "TAlk")), # NB: stoichiometry is *-1
     deltavarname_eta = ("SO4_delta", -35.0),   # constant fractionation 35 per mil
     sms_prefix="soluteflux_",
     sms_suffix="",


### PR DESCRIPTION
Bug fixes for Fe-S system alkalinity

Also ReactionFeSaq add a new add_TAlk_calc option: add H2S alkalinity contribution to `TAlk_calc` provided by a carbonate chemistry solver.

ReactionFeSaq can now be used in combination with a separate carbonate chemistry calculation, where ReactionFeSaq handles H2S speciation, and the carbonate chemistry solver eg ReactionCO2SYS handles everything else (but *not* H2S).