### PR TITLE
Fix ReactionFluxToComponents with optional (unlinked) outputflux

### DIFF
--- a/src/Particle.jl
+++ b/src/Particle.jl
@@ -159,6 +159,10 @@ function do_flux_to_components(
         end
         return nothing
     end
+     # outflux is not linked
+     function do_outflux(outflux::Nothing, _, _)
+        return nothing
+    end
 
     PB.IteratorUtils.foreach_longtuple_p(
         do_outflux, vars_outflux, pars.outputflux_stoich, var_inputflux


### PR DESCRIPTION
Fix https://github.com/PALEOtoolkit/PALEOaqchem.jl/issues/30 - error if an outputflux is not linked
(the code allowed optional ie unlinked outputflux in the list, but then errored when trying to solve the model)