### PR TITLE
Fix incorrect deprecation syntax

### DIFF
--- a/src/PALEOaqchem.jl
+++ b/src/PALEOaqchem.jl
@@ -37,8 +37,8 @@ function O2AlkUptakeRemin(Corg, (NO3, TNH3, Ngas), TPO4, Ccarb; rO2Corg=1)
     return (O2, Alk)
 end
 
-Base.@deprecate_moved parse_number_name "PALEOboxes"
-Base.@deprecate_moved parse_name_to_power_number "PALEOboxes"
+Base.@deprecate_binding parse_number_name PB.parse_number_name
+Base.@deprecate_binding parse_name_to_power_number PB.parse_name_to_power_number
 
 const _R_conc_attributes_base = (
     # :field_data=>rj.pars.field_data[],


### PR DESCRIPTION
Correct way to move a function from PALEOaqchem to PALEOboxes (abbreviated PB):

    Base.@deprecate_binding parse_number_name PB.parse_number_name
    Base.@deprecate_binding parse_name_to_power_number PB.parse_name_to_power_number

this means old code still works, but gives an informative warning if julia is started with '--depwarn=yes'

Incorrect way:

    Base.@deprecate_moved parse_number_name "PALEOboxes"
    Base.@deprecate_moved parse_name_to_power_number "PALEOboxes"

this means old code gives a fatal error explaining how to update the code, which is not what we want here...